### PR TITLE
Fixed broken link in wifi.md

### DIFF
--- a/wifi.md
+++ b/wifi.md
@@ -13,6 +13,6 @@ If you want to connect your Raspberry Pi to the internet or local network then y
 
 ## What next?
 
-- Return to the [Raspberry Pi Software Guide](worksheet.md)
+- Return to the [Raspberry Pi Software Guide](quickstart.md)
 - Learn how to [update your SD card](update-sd-card.md)
 - Install more [applications](install-apps.md)


### PR DESCRIPTION
Hello,

While browsing the Software Guide, I noticed a broken link in the wifi.md file. The link to Raspberry Pi Software Guide in "What's next" section was pointing to "worksheet.md", I changed it to point to "quickstart.md".

This is linked to issue #7.

Please consider merging.